### PR TITLE
Deleting saved capture folder

### DIFF
--- a/server/frontend/app/classes/save.py
+++ b/server/frontend/app/classes/save.py
@@ -50,11 +50,13 @@ class Save():
                 if method == "usb":
                     cd = datetime.now().strftime("%d%m%Y-%H%M")
                     if shutil.make_archive("{}/TinyCheck_{}".format(self.mount_point, cd), "zip", "/tmp/{}/".format(token)):
+                        shutil.rmtree("/tmp/{}/".format(token))
                         return jsonify({"status": True,
                                         "message": "Capture saved on the USB key"})
                 elif method == "url":
                     cd = datetime.now().strftime("%d%m%Y-%H%M")
                     if shutil.make_archive("/tmp/TinyCheck_{}".format(cd), "zip", "/tmp/{}/".format(token)):
+                        shutil.rmtree("/tmp/{}/".format(token))
                         with open("/tmp/TinyCheck_{}.zip".format(cd), "rb") as f:
                             return send_file(
                                 io.BytesIO(f.read()),


### PR DESCRIPTION
Even if they were saved in `/tmp/` the capture folders weren't deleted after being compressed and saved on the USB key or by direct download. Still exists a "race condition" if we don't save the capture, it will reside in `/tmp/`. I'm gonna to see tomorrow the best way to delete these previous captures too.