### PR TITLE
FIX watcher crash when remote file does not have a "to_delete" key

### DIFF
--- a/server/backend/watchers.py
+++ b/server/backend/watchers.py
@@ -37,6 +37,7 @@ def watch_iocs():
             if w["status"] == False:
                 iocs = IOCs()
                 iocs_list = []
+                to_delete = []
                 try:
                     res = requests.get(w["url"], verify=False)
                     if res.status_code == 200:
@@ -85,6 +86,7 @@ def watch_whitelists():
             if w["status"] == False:
                 whitelist = WhiteList()
                 elements = []
+                to_delete = []
                 try:
                     res = requests.get(w["url"], verify=False)
                     if res.status_code == 200:


### PR DESCRIPTION
The current main's server/backend/watchers.py file [iterates over variables that are not initialized](https://github.com/KasperskyLab/TinyCheck/blob/4b9413ba3732b8c680cfe52960b2bd79abce44ed/server/backend/watchers.py#L59) to an iterable element (_to_delete_). Other similar lists are correctly initialized, and their content parsing methods check on expected keys existence in read JSON.

In case the remote IOCs feed does not have a "to_delete" index in its IOCs JSON dictionary, the watchers service will then stop from an NameError exception (as the iterated variable does not exist). The fix is way more easy than the issue explanation :)

```
$ service tinycheck-watchers status
● tinycheck-watchers.service - TinyCheck watchers service
   Loaded: loaded (/lib/systemd/system/tinycheck-watchers.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since [...]
  Process: 23358 ExecStart=/usr/bin/python3 /usr/share/tinycheck/server/backend/watchers.py (code=exited, status=0/SUCCESS)
 Main PID: 23358 (code=exited, status=0/SUCCESS)

[...]
tinycheck python3[23358]:   File "/usr/share/tinycheck/server/backend/watchers.py", line 60, in watch_iocs
tinycheck python3[23358]:     for ioc in to_delete:
tinycheck python3[23358]: NameError: name 'to_delete' is not defined
```