### PR TITLE
Make the frontend port configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,6 +52,7 @@ frontend:
   user_lang: userlang
   update: updateoption
   choose_net: false
+  http_port: 80
   
 # NETWORK -
 # Some elements related to the network configuration, such as

--- a/server/frontend/main.py
+++ b/server/frontend/main.py
@@ -51,7 +51,6 @@ if __name__ == '__main__':
         port = int(read_config(("frontend", "http_port")))
     except:
         port = 80
-    print(port)
     if read_config(("frontend", "remote_access")):
         app.run(host="0.0.0.0", port=port)
     else:

--- a/server/frontend/main.py
+++ b/server/frontend/main.py
@@ -46,7 +46,13 @@ app.register_blueprint(misc_bp, url_prefix='/api/misc')
 app.register_blueprint(update_bp, url_prefix='/api/update')
 
 if __name__ == '__main__':
+    port = ""
+    try:
+        port = int(read_config(("frontend", "http_port")))
+    except:
+        port = 80
+    print(port)
     if read_config(("frontend", "remote_access")):
-        app.run(host="0.0.0.0", port=80)
+        app.run(host="0.0.0.0", port=port)
     else:
-        app.run(port=80)
+        app.run(port=port)


### PR DESCRIPTION
added a configuration item for frontend/http_port
changed the frontend main.py to read and use that configuration item. default to 80 if it is missing (for backward compatibility)
