### PR TITLE
Change hardcoded paths make analysis.py usable standalone

### DIFF
--- a/analysis/classes/report.py
+++ b/analysis/classes/report.py
@@ -13,7 +13,7 @@ from utils import get_config
 
 class Report(object):
 
-    def __init__(self, capture_directory):
+    def __init__(self, capture_directory, frontend):
         self.capture_directory = capture_directory
         self.alerts = self.read_json(os.path.join(
             capture_directory, "assets/alerts.json"))
@@ -21,10 +21,13 @@ class Report(object):
             capture_directory, "assets/whitelist.json"))
         self.conns = self.read_json(os.path.join(
             capture_directory, "assets/conns.json"))
-        self.device = self.read_json(os.path.join(
-            capture_directory, "assets/device.json"))
-        self.capinfos = self.read_json(os.path.join(
-            capture_directory, "assets/capinfos.json"))
+        self.device = None
+        self.capinfos = None
+        if frontend:
+            self.device = self.read_json(os.path.join(
+                capture_directory, "assets/device.json"))
+            self.capinfos = self.read_json(os.path.join(
+                capture_directory, "assets/capinfos.json"))
         try:
             with open(os.path.join(self.capture_directory, "capture.pcap"), "rb") as f:
                 self.capture_sha1 = hashlib.sha1(f.read()).hexdigest()
@@ -204,16 +207,18 @@ class Report(object):
         """
         header = "<div class=\"header\">"
         header += "<div class=\"logo\"></div>"
-        header += "<p><br /><strong>{}: {}</strong><br />".format(self.template["device_name"],
+        if self.device is not None:
+            header += "<p><br /><strong>{}: {}</strong><br />".format(self.template["device_name"],
                                                                   self.device["name"])
-        header += "{}: {}<br />".format(self.template["device_mac"],
+            header += "{}: {}<br />".format(self.template["device_mac"],
                                         self.device["mac_address"])
         header += "{} {}<br />".format(self.template["report_generated_on"],
                                        datetime.now().strftime("%d/%m/%Y - %H:%M:%S"))
-        header += "{}: {}s<br />".format(self.template["capture_duration"],
-                                         self.capinfos["Capture duration"])
-        header += "{}: {}<br />".format(self.template["packets_number"],
-                                        self.capinfos["Number of packets"])
+        if self.capinfos is not None:
+            header += "{}: {}s<br />".format(self.template["capture_duration"],
+                                             self.capinfos["Capture duration"])
+            header += "{}: {}<br />".format(self.template["packets_number"],
+                                            self.capinfos["Number of packets"])
         header += "{}: {}<br />".format(
             self.template["capture_sha1"], self.capture_sha1)
         header += "</p>"

--- a/analysis/classes/zeekengine.py
+++ b/analysis/classes/zeekengine.py
@@ -236,6 +236,7 @@ class ZeekEngine(object):
                     pass
 
                 try:  # Domain history check.
+
                     whois_record = whois.whois(c["resolution"])
                     creation_date = whois_record.creation_date if type(
                         whois_record.creation_date) is not list else whois_record.creation_date[0]
@@ -247,6 +248,7 @@ class ZeekEngine(object):
                                             "host": c["resolution"],
                                             "level": "Moderate",
                                             "id": "ACT-02"})
+
                 except:
                     pass
 
@@ -443,11 +445,10 @@ class ZeekEngine(object):
         """
             Start zeek and check the logs.
         """
-        sp.Popen("cd {} && /opt/zeek/bin/zeek -Cr capture.pcap protocols/ssl/validate-certs".format(
+        sp.Popen("cd {} && zeek -Cr capture.pcap protocols/ssl/validate-certs".format(
             self.working_dir), shell=True).wait()
         sp.Popen("cd {} && mv *.log assets/".format(self.working_dir),
                  shell=True).wait()
-
         self.fill_dns(self.working_dir + "/assets/")
         self.netflow_check(self.working_dir + "/assets/")
         self.ssl_check(self.working_dir + "/assets/")

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -10,7 +10,7 @@ import os
 from functools import reduce
 
 # I'm not going to use an ORM for that.
-parent = "/".join(sys.path[0].split("/")[:-1])
+parent = os.path.split(os.path.dirname(os.path.abspath(sys.argv[0])))[0]
 conn = sqlite3.connect(os.path.join(parent, "tinycheck.sqlite3"))
 cursor = conn.cursor()
 

--- a/server/frontend/app/classes/analysis.py
+++ b/server/frontend/app/classes/analysis.py
@@ -24,7 +24,7 @@ class Analysis(object):
         if self.token is not None:
             parent = "/".join(sys.path[0].split("/")[:-2])
             sp.Popen(
-                [sys.executable, "{}/analysis/analysis.py".format(parent), "/tmp/{}".format(self.token)])
+                [sys.executable, "{}/analysis/analysis.py".format(parent), "-f", "/tmp/{}".format(self.token)])
             return {"status": True,
                     "message": "Analysis started",
                     "token": self.token}


### PR DESCRIPTION
I wanted to use analysis.py directly without necessarily installing TinyCheck or using the frontend. Also I didn't want to use it on a Raspberry Pi. For example this is useful for analyzing .pcap's obtained from VMs running on a PC. 
These changes shouldn't interfere with running on a Raspi with the frontend but make TinyCheck more partable.